### PR TITLE
fix: corrected error in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ app = FastAPI()
 
 @app.get("/items")
 def read_items():
-    result = 1 + 1
+    some_var = 1
+    result = 1 + some_var
     return {"result": result}
 
 


### PR DESCRIPTION
When making a request to the `/items` endpoint, the API returns a 500 error. \r\nWhen checking the server log, I found the following error: NameError: name ‘some_var’ is not defined\r\nThe error may be in the main.py file, where the API code is located.