### PR TITLE
Fix: Resolve issue with number 36

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,15 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/items")
 def read_items():
     n = "2"
-    result = n + 1
+    result = int(n) + 1
     return {"result": result}
+
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)


### PR DESCRIPTION
This pull request fixes issue #36. The API was returning a 500 error when making a request to the /items endpoint. This was due to a TypeError: can only concatenate str (not \"int\") to str. The issue has been resolved by converting the string 'n' to an integer before adding 1.