### PR TITLE
fix: solve issue #36

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,12 +2,15 @@ from fastapi import FastAPI
 
 app = FastAPI()
 
+
 @app.get("/items")
 def read_items():
-    n = "2"
-    result = n + 1
+    n = 2
+    result = str(n + 1)
     return {"result": result}
+
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=True)


### PR DESCRIPTION
Fix: solve issue #36. The API was returning a 500 error when making a request to the /items endpoint. This was happening because of a TypeError: can only concatenate str (not \"int\") to str. This PR solves the issue by converting the integer to a string before concatenating it.